### PR TITLE
Fix SubTier values so they are parsed correctly.

### DIFF
--- a/spnkr/parsers/refdata.py
+++ b/spnkr/parsers/refdata.py
@@ -1,6 +1,6 @@
 """Enumerated data types used by the Halo Infinite API."""
 
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 
 
 class AssetKind(IntEnum):
@@ -167,23 +167,35 @@ class SkillResultCode(IntEnum):
     """Skill request was successful."""
 
 
-class SubTier(IntEnum):
-    """Sub-tiers of skill rankings."""
+class SubTier(Enum):
+    """Sub-tiers of skill rankings.
 
-    NOT_APPLICABLE = 0
-    """Not applicable."""
-    ONE = 1
+    The `value` attribute of the sub-tier items is the index of the sub-tier,
+    starting at 0 for the 1st sub-tier and incrementing as sub-tier increases.
+    The `to_int` method returns the true sub-tier value, e.g., "ONE" returns 1.
+    """
+
+    ONE = 0
     """1st sub-tier."""
-    TWO = 2
+    TWO = 1
     """2nd sub-tier."""
-    THREE = 3
+    THREE = 2
     """3rd sub-tier."""
-    FOUR = 4
+    FOUR = 3
     """4th sub-tier."""
-    FIVE = 5
+    FIVE = 4
     """5th sub-tier."""
-    SIX = 6
+    SIX = 5
     """6th sub-tier. Highest sub-tier before advancing to the next tier."""
+
+    @classmethod
+    def from_int(cls, value: int) -> "SubTier":
+        """Return the sub-tier from an integer value."""
+        return cls(value - 1)
+
+    def to_int(self) -> int:
+        """Return the integer value of the sub-tier. For example, "ONE" => 1."""
+        return self.value + 1
 
 
 class Tier(StrEnum):

--- a/spnkr/tools.py
+++ b/spnkr/tools.py
@@ -73,7 +73,7 @@ class Rank(NamedTuple):
     def __str__(self) -> str:
         if self.tier is Tier.ONYX:
             return self.tier.value
-        return f"{self.tier.value} {self.sub_tier.value}"
+        return f"{self.tier.value} {self.sub_tier.to_int()}"
 
 
 def get_rank_from_csr(csr: int | float) -> Rank:
@@ -98,7 +98,6 @@ def get_rank_from_csr(csr: int | float) -> Rank:
     elif quotient == 4:
         tier = Tier.DIAMOND
     else:
-        # Onyx doesn't have sub-tiers
-        return Rank(Tier.ONYX, SubTier.NOT_APPLICABLE)
-    sub_tier = SubTier((remainder // 50) + 1)
+        return Rank(Tier.ONYX, SubTier.ONE)
+    sub_tier = SubTier.from_int((remainder // 50) + 1)
     return Rank(tier, sub_tier)

--- a/tests/test_refdata.py
+++ b/tests/test_refdata.py
@@ -1,0 +1,26 @@
+"""Test the spnkr.parsers.refdata module."""
+
+import pytest
+
+from spnkr.parsers.refdata import SubTier
+
+SUBTIER_VALUES = [
+    (SubTier.ONE, 1),
+    (SubTier.TWO, 2),
+    (SubTier.THREE, 3),
+    (SubTier.FOUR, 4),
+    (SubTier.FIVE, 5),
+    (SubTier.SIX, 6),
+]
+
+
+@pytest.mark.parametrize("subtier, value", SUBTIER_VALUES)
+def test_subtier_from_int(subtier: SubTier, value: int):
+    """Test the from_int method of the SubTier class."""
+    assert SubTier.from_int(value) == subtier
+
+
+@pytest.mark.parametrize("subtier, value", SUBTIER_VALUES)
+def test_subtier_to_int(subtier: SubTier, value: int):
+    """Test the as_int method of the SubTier class."""
+    assert subtier.to_int() == value

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,8 +18,8 @@ CSR_TIERS = [
     (1199, Tier.PLATINUM, SubTier.SIX),
     (1200, Tier.DIAMOND, SubTier.ONE),
     (1499, Tier.DIAMOND, SubTier.SIX),
-    (1500, Tier.ONYX, SubTier.NOT_APPLICABLE),
-    (3000, Tier.ONYX, SubTier.NOT_APPLICABLE),
+    (1500, Tier.ONYX, SubTier.ONE),
+    (3000, Tier.ONYX, SubTier.ONE),
 ]
 
 
@@ -31,7 +31,7 @@ def test_ranking_str():
 
 def test_ranking_str_onyx():
     """Test the __str__ method of the Rank class when the tier is Onyx."""
-    ranking = tools.Rank(Tier.ONYX, SubTier.NOT_APPLICABLE)
+    ranking = tools.Rank(Tier.ONYX, SubTier.ONE)
     assert str(ranking) == "Onyx"
 
 


### PR DESCRIPTION
Sub tiers are represented in JSON payloads as a zero-based index. Also change SubTier class to inherit from Enum instead of IntEnum to avoid potential int comparison confusion.

Closes #9 