### PR TITLE
Distribute client methods to services based on URL host.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-11-30
+
+### Changed
+
+- Grouped endpoints by their URL hosts to create a `services` module. The data retrieval methods didn't change, but they did move to their respective service classes. `HaloInfiniteClient` remains the core API entrypoint, but now indirectly serves data via cached service properties `gamecms_hacs`, `profile`, `discovery_ugc`, `skill`, and `stats`. This will make adding more services and endpoints more graceful than just appending more methods to the client class. Additionally, this design makes it easy to rate-limit requests per host rather than globally.
+
 ## [0.2.0] - 2023-11-28
 
 ### Added
@@ -29,8 +35,9 @@
 
 ## [0.1.0] - 2023-08-24
 
-First release.
+First documented release.
 
-[unreleased]: https://github.com/acurtis166/SPNKr/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/acurtis166/SPNKr/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/acurtis166/SPNKr/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/acurtis166/SPNKr/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/acurtis166/SPNKr/releases/tag/v0.1.0

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -102,7 +102,7 @@ async def main() -> None:
         client = HaloInfiniteClient(...)
 
         # Request the 25 most recent matches for the player.
-        response = await client.get_match_history(PLAYER)
+        response = await client.stats.get_match_history(PLAYER)
 
 
 if __name__ == "__main__":
@@ -111,12 +111,12 @@ if __name__ == "__main__":
 
 ## Parsing Responses
 
-API calls return JSON payloads, but these are not deserialized by the client. Instead, client methods return raw `aiohttp.ClientResponse` objects to be handled by the user. That being said, two built-in parsing strategies are available.
+API calls return JSON payloads, but these are not decoded. Instead, methods return raw `aiohttp.ClientResponse` objects to be handled by the user. That being said, two built-in parsing strategies are available.
 
 - [Pydantic parsing](reference/pydantic-parsing.md) - Parse JSON responses into [Pydantic](https://docs.pydantic.dev/latest/) models.
 - [Records parsing](reference/records-parsing.md) - Parse JSON responses into flat, record-like named tuples with only highlighted information. While not as complete as the Pydantic models, they are likely more convenient to load into a `pandas.DataFrame` or dump to files/databases.
 
-The classes and functions for these parsers are available in the `spnkr.parsers` module. Relevant parsing objects are referenced by the [HaloInfiniteClient](reference/client.md) methods.
+The classes and functions for these parsers are available in the `spnkr.parsers` module. Relevant parsing objects are referenced by the [service methods](reference/services.md).
 
 Below is a continuation of our above script with parsing of the JSON into a [MatchHistory](reference/pydantic-parsing.md#spnkr.parsers.pydantic.stats.MatchHistory) Pydantic model.
 
@@ -132,7 +132,7 @@ from spnkr.parsers.pydantic import MatchHistory
 async def main() -> None:
     async with ClientSession() as session:
         client = HaloInfiniteClient(...)
-        response = await client.get_match_history(...)
+        response = await client.stats.get_match_history(...)
 
         # Deserialize the JSON response
         data = await response.json()
@@ -153,6 +153,6 @@ if __name__ == "__main__":
 
     If you would prefer to parse responses yourself, it may help to look at some [examples](https://github.com/acurtis166/spnkr/tree/master/tests/responses)
 
-Of course, there are additional methods for retrieving statistics or skill information about matches. Click the button below to see them all.
+Of course, there are additional methods for retrieving stats, CSR/MMR, and metadata information.
 
-[Next: Client Methods](reference/client.md#spnkr.client.HaloInfiniteClient){ .md-button }
+[Next: Services](reference/services.md){ .md-button }

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -1,3 +1,5 @@
-# Halo Infinite Client
+# Client
 
-::: spnkr.client.HaloInfiniteClient
+::: spnkr.client
+    options:
+        show_root_heading: false

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -1,0 +1,16 @@
+# Services
+
+::: spnkr.services
+    options:
+        show_root_heading: false
+        show_bases: false
+
+<!-- ::: spnkr.services.DiscoveryUgcService
+
+::: spnkr.services.GameCmsHacsService
+
+::: spnkr.services.ProfileService
+
+::: spnkr.services.SkillService
+
+::: spnkr.services.StatsService -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - Reference:
     - reference/authentication.md
     - reference/client.md
+    - reference/services.md
     - reference/pydantic-parsing.md
     - reference/records-parsing.md
     - reference/reference-data.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'spnkr'
-version = '0.2.0'
+version = '0.3.0'
 description = 'Python API for retrieving Halo Infinite multiplayer data.'
 readme = 'README.md'
 authors = [{name = 'Andy Curtis'}]

--- a/scripts/download_match_skill.py
+++ b/scripts/download_match_skill.py
@@ -28,7 +28,7 @@ async def make_request(
     out_path: Path,
 ) -> tuple[str, int, str | None]:
     """Make a request to the Halo Infinite API and save the response."""
-    response = await client.get_match_skill(match_id, xuids)
+    response = await client.skill.get_match_skill(match_id, xuids)
     if not response.ok:
         # Requests may fail as not found or bad request.
         return match_id, response.status, response.reason

--- a/scripts/download_match_stats.py
+++ b/scripts/download_match_stats.py
@@ -27,7 +27,7 @@ async def make_request(
     out_path: Path,
 ) -> str:
     """Make a request to the Halo Infinite API and save the response."""
-    response = await client.get_match_stats(match_id)
+    response = await client.stats.get_match_stats(match_id)
     file_name = f"{match_id}.json"
     async with aiofiles.open(out_path / file_name, "wb") as f:
         async for data in response.content.iter_chunked(1024):

--- a/scripts/get_gamertags.py
+++ b/scripts/get_gamertags.py
@@ -26,7 +26,7 @@ async def main(xuids: list[str]) -> None:
         spartan = player.spartan_token.token
         clearance = player.clearance_token.token
         client = HaloInfiniteClient(session, spartan, clearance)
-        response = await client.get_users_by_id(xuids)
+        response = await client.profile.get_users_by_id(xuids)
         data = await response.json()
         users = [User(**user) for user in data]
         for user in users:

--- a/scripts/get_history_records.py
+++ b/scripts/get_history_records.py
@@ -30,7 +30,7 @@ async def iter_matches(
     start = 0
     while count == 25:
         print(f"Retrieving matches {start + 1} to {start + count}...")
-        response = await client.get_match_history(xuid, start, count)
+        response = await client.stats.get_match_history(xuid, start, count)
         history = parse_match_history(await response.json())
         for match in history:
             yield match

--- a/scripts/get_metadata_records.py
+++ b/scripts/get_metadata_records.py
@@ -73,21 +73,22 @@ async def main(match_history_path: Path, out_path: Path) -> None:
 
         # Get the assets and medals.
         maps = await asyncio.gather(
-            get_asset(client.get_map, aid, vid) for aid, vid in map_ids
+            get_asset(client.discovery_ugc.get_map, aid, vid)
+            for aid, vid in map_ids
         )
         modes = await asyncio.gather(
-            get_asset(client.get_ugc_game_variant, aid, vid)
+            get_asset(client.discovery_ugc.get_ugc_game_variant, aid, vid)
             for aid, vid in mode_ids
         )
         playlists = await asyncio.gather(
-            get_asset(client.get_playlist, aid, vid)
+            get_asset(client.discovery_ugc.get_playlist, aid, vid)
             for aid, vid in playlist_ids
         )
         map_modes = await asyncio.gather(
-            get_asset(client.get_map_mode_pair, aid, vid)
+            get_asset(client.discovery_ugc.get_map_mode_pair, aid, vid)
             for aid, vid in map_mode_ids
         )
-        medal_response = await client.get_medal_metadata()
+        medal_response = await client.gamecms_hacs.get_medal_metadata()
         medals = parse_medal_metadata(await medal_response.json())
 
     # Write the assets and medals to CSV files.

--- a/spnkr/client.py
+++ b/spnkr/client.py
@@ -6,37 +6,19 @@ https://settings.svc.halowaypoint.com/settings/hipc/e2a0a7c6-6efe-42af-9283-c2ab
 Additionally inspected the network traffic while navigating Halo Waypoint.
 """
 
-import warnings
-from typing import Iterable, Literal
-from uuid import UUID
+from functools import cached_property
 
-from aiohttp import ClientResponse, ClientSession
-from aiolimiter import AsyncLimiter
+from aiohttp import ClientSession
 
-from .parsers.refdata import GameVariantCategory
-from .xuid import unwrap_xuid, wrap_xuid, wrap_xuid_or_gamertag
+from .services import (
+    DiscoveryUgcService,
+    GameCmsHacsService,
+    ProfileService,
+    SkillService,
+    StatsService,
+)
 
-GAMECMS_HACS_HOST = "https://gamecms-hacs.svc.halowaypoint.com"
-SKILL_HOST = "https://skill.svc.halowaypoint.com:443"
-STATS_HOST = "https://halostats.svc.halowaypoint.com:443"
-UGC_DISCOVERY_HOST = "https://discovery-infiniteugc.svc.halowaypoint.com:443"
-PROFILE_HOST = "https://profile.svc.halowaypoint.com"
-
-_VALID_SERVICE_RECORD_FILTER_SETS = [
-    {"season_id"},
-    {"season_id", "game_variant_category"},
-    {"season_id", "game_variant_category", "playlist_asset_id"},
-    {"season_id", "game_variant_category", "is_ranked"},
-    {"season_id", "playlist_asset_id"},
-    {"game_variant_category"},
-    {"game_variant_category", "is_ranked"},
-]
-
-
-def _create_limiter(rate_per_second: int) -> AsyncLimiter:
-    """Return an AsyncLimiter with the given rate per second."""
-    # Setting the max rate to 1 disallows bursts.
-    return AsyncLimiter(1, 1 / rate_per_second)
+__all__ = ["HaloInfiniteClient"]
 
 
 class HaloInfiniteClient:
@@ -51,7 +33,7 @@ class HaloInfiniteClient:
     ) -> None:
         """Initialize a client for the Halo Infinite API.
 
-        Raw `aiohttp` `ClientResponses` are returned from each method. The
+        Raw `aiohttp.ClientResponses` are returned from each method. The
         caller is responsible for handling the response via custom parsing or by
         using one of the provided parsers from the `spnkr.parsers` module.
 
@@ -60,376 +42,38 @@ class HaloInfiniteClient:
             spartan_token: The spartan token used to authenticate with the API.
             clearance_token: The clearance token used to authenticate with the
                 API.
-            requests_per_second: The rate limit to use. Defaults to 5 requests
-                per second. Set to None to disable rate limiting.
+            requests_per_second: The rate limit to use. Note that this rate
+                limit is enforced per service, not globally. Defaults to 5
+                requests per second. Set to None to disable rate limiting.
         """
+        session.headers.clear()
+        session.headers["Accept"] = "application/json"
+        session.headers["x-343-authorization-spartan"] = spartan_token
+        session.headers["343-clearance"] = clearance_token
         self._session = session
-        headers = {
-            "Accept": "application/json",
-            "x-343-authorization-spartan": spartan_token,
-            "343-clearance": clearance_token,
-        }
-        self._session.headers.update(headers)
-
-        self._rate_limiter = None
-        if requests_per_second is not None:
-            self._rate_limiter = _create_limiter(requests_per_second)
-
-    async def _get(self, url: str, **kwargs) -> ClientResponse:
-        """Make a GET request to the given URL."""
-        if self._rate_limiter is None:
-            return await self._session.get(url, **kwargs)
-        async with self._rate_limiter:
-            return await self._session.get(url, **kwargs)
-
-    async def get_medal_metadata(self) -> ClientResponse:
-        """Get details for all medals obtainable in the game.
-
-        Parsers:
-            - [MedalMetadata][spnkr.parsers.pydantic.gamecms_hacs.MedalMetadata]
-            - [parse_medal_metadata][spnkr.parsers.records.gamecms_hacs.parse_medal_metadata]
-
-        Returns:
-            The medal metadata.
-        """
-        url = f"{GAMECMS_HACS_HOST}/hi/Waypoint/file/medals/metadata.json"
-        return await self._get(url)
-
-    async def get_match_skill(
-        self, match_id: str | UUID, xuids: Iterable[str | int]
-    ) -> ClientResponse:
-        """Get player CSR and team MMR values for a given match and player list.
-
-        Args:
-            match_id: Halo Infinite match ID.
-            xuids: The Xbox Live IDs of the match's players. Only
-                players in this list will have their skill data returned.
-
-        Parsers:
-            - [MatchSkill][spnkr.parsers.pydantic.skill.MatchSkill]
-            - [parse_match_skill][spnkr.parsers.records.skill.parse_match_skill]
-
-        Returns:
-            The skill data for the match.
-        """
-        url = f"{SKILL_HOST}/hi/matches/{match_id}/skill"
-        params = {"players": [wrap_xuid(x) for x in xuids]}
-        return await self._get(url, params=params)
-
-    async def get_playlist_csr(
-        self, playlist_id: str | UUID, xuids: Iterable[str | int]
-    ) -> ClientResponse:
-        """Get player CSR values for a given playlist and player list.
-
-        Args:
-            playlist_id: Halo Infinite playlist asset ID.
-            xuids: The Xbox Live IDs of the players.
-
-        Parsers:
-            - [PlaylistCsr][spnkr.parsers.pydantic.skill.PlaylistCsr]
-            - [parse_playlist_csr][spnkr.parsers.records.skill.parse_playlist_csr]
-
-        Returns:
-            The summary CSR data for the players in the given playlist.
-        """
-        url = f"{SKILL_HOST}/hi/playlist/{playlist_id}/csrs"
-        params = {"players": [wrap_xuid(x) for x in xuids]}
-        return await self._get(url, params=params)
-
-    async def get_match_count(self, player: str | int) -> ClientResponse:
-        """Get match counts across different game experiences for a player.
-
-        The counts returned are for custom matches, matchmade matches, local
-        matches, and total matches.
-
-        Args:
-            player: Xbox Live ID or gamertag of the player to get counts for.
-                Examples of valid inputs include "xuid(1234567890123456)",
-                "1234567890123456", 1234567890123456, and "MyGamertag".
-
-        Parsers:
-            - [MatchCount][spnkr.parsers.pydantic.stats.MatchCount]
-            - [parse_match_count][spnkr.parsers.records.stats.parse_match_count]
-
-        Returns:
-            The match counts.
-        """
-        xuid_or_gamertag = wrap_xuid_or_gamertag(player)
-        url = f"{STATS_HOST}/hi/players/{xuid_or_gamertag}/matches/count"
-        return await self._get(url)
-
-    async def get_service_record(
-        self,
-        player: str | int,
-        match_type: Literal["matchmade", "custom", "local"] = "matchmade",
-        season_id: str | None = None,
-        game_variant_category: GameVariantCategory | int | None = None,
-        is_ranked: bool | None = None,
-        playlist_asset_id: str | UUID | None = None,
-    ) -> ClientResponse:
-        """Get a service record for a player. Summarizes player stats.
-
-        Note that filters (`season_id`, `game_variant_category`, `is_ranked`,
-        and `playlist_asset_id`) are only applicable to "matchmade"
-        `match_type`. A warning is issued and the filters are ignored if they
-        are provided for a non-matchmade `match_type`.
-
-        Filters must be combined appropriately. The following are valid:
-        - `season_id`
-        - `season_id`, `game_variant_category`
-        - `season_id`, `game_variant_category`, `playlist_asset_id`
-        - `season_id`, `game_variant_category`, `is_ranked`
-        - `season_id`, `playlist_asset_id`
-        - `game_variant_category`
-        - `game_variant_category`, `is_ranked`
-
-        To collect possible values for the filter arguments, look at the
-        "subqueries" attribute of an unfiltered service record response.
-
-        Args:
-            player: Xbox Live ID or gamertag of the player to get counts for.
-                Examples of valid inputs include "xuid(1234567890123456)",
-                "1234567890123456", 1234567890123456, and "MyGamertag".
-            match_type: The type of games to include in the service record.
-                One of "matchmade", "custom", or "local".
-            season_id: The season ID to get service record for. Optional.
-            game_variant_category: The game variant category to filter service
-                record data. See `spnkr.parsers.refdata.GameVariantCategory` for
-                human-readable values. Optional.
-            is_ranked: Filter for ranked or unranked games. Optional.
-            playlist_asset_id: Filter for a specific playlist with its asset ID.
-                Optional.
-
-        Parsers:
-            - [ServiceRecord][spnkr.parsers.pydantic.stats.ServiceRecord]
-            - [parse_service_record][spnkr.parsers.records.stats.parse_service_record]
-
-        Returns:
-            The service record for the player with the given filters.
-
-        Raises:
-            ValueError: If `match_type` is not one of "matchmade", "custom", or
-                "local".
-            ValueError: If filter arguments are inappropriately combined.
-        """
-        if match_type.lower() not in ("matchmade", "custom", "local"):
-            raise ValueError(f"Invalid match type: {match_type}")
-        xuid_or_gamertag = wrap_xuid_or_gamertag(player)
-        endpoint = f"/hi/players/{xuid_or_gamertag}/{match_type}/servicerecord"
-        url = f"{STATS_HOST}{endpoint}"
-        filters = {
-            "season_id": season_id,
-            "game_variant_category": game_variant_category,
-            "is_ranked": is_ranked,
-            "playlist_asset_id": playlist_asset_id,
-        }
-        filters = {k: v for k, v in filters.items() if v is not None}
-        if match_type.lower() != "matchmade" and filters:
-            warnings.warn(
-                "Service record filters are only applicable to matchmade games."
-            )
-            filters = {}
-        if filters and set(filters) not in _VALID_SERVICE_RECORD_FILTER_SETS:
-            valid = "\n".join(str(s) for s in _VALID_SERVICE_RECORD_FILTER_SETS)
-            raise ValueError(
-                f"Invalid filter combination: {filters}. Options:\n{valid}"
-            )
-        params = {k.replace("_", ""): str(v) for k, v in filters.items()}
-        return await self._get(url, params=params)
-
-    async def get_match_history(
-        self,
-        player: str | int,
-        start: int = 0,
-        count: int = 25,
-        match_type: Literal["all", "matchmaking", "custom", "local"] = "all",
-    ) -> ClientResponse:
-        """Request a batch of matches from a player's match history.
-
-        Args:
-            player: Xbox Live ID or gamertag of the player to get counts for.
-                Examples of valid inputs include "xuid(1234567890123456)",
-                "1234567890123456", 1234567890123456, and "MyGamertag".
-            start: Index of the first match to request, starting at 0.
-            count: The number of matches to request. Maximum number of results
-                returned is 25.
-            match_type: The type of matches to return. One of "all",
-                "matchmaking", "custom", or "local".
-
-        Parsers:
-            - [MatchHistory][spnkr.parsers.pydantic.stats.MatchHistory]
-            - [parse_match_history][spnkr.parsers.records.stats.parse_match_history]
-
-        Returns:
-            The requested match history "page" of results.
-        """
-        xuid_or_gamertag = wrap_xuid_or_gamertag(player)
-        url = f"{STATS_HOST}/hi/players/{xuid_or_gamertag}/matches"
-        params = {"start": start, "count": count, "type": match_type}
-        return await self._get(url, params=params)
-
-    async def get_match_stats(self, match_id: str | UUID) -> ClientResponse:
-        """Request match details using the Halo Infinite match GUID.
-
-        Args:
-            match_id: Halo Infinite GUID identifying the match.
-
-        Parsers:
-            - [MatchStats][spnkr.parsers.pydantic.stats.MatchStats]
-            - [parse_match_info][spnkr.parsers.records.stats.parse_match_info]
-            - [parse_player_core_stats][spnkr.parsers.records.stats.parse_player_core_stats]
-            - [parse_player_medals][spnkr.parsers.records.stats.parse_player_medals]
-            - [parse_team_core_stats][spnkr.parsers.records.stats.parse_team_core_stats]
-
-        Returns:
-            The match details.
-        """
-        url = f"{STATS_HOST}/hi/matches/{match_id}/stats"
-        return await self._get(url)
-
-    async def get_ugc_game_variant(
-        self, asset_id: str | UUID, version_id: str | UUID
-    ) -> ClientResponse:
-        """Get details about a game mode.
-
-        Args:
-            asset_id: The asset ID of the game variant.
-            version_id: The version ID of the game variant.
-
-        Parsers:
-            - [UgcGameVariant][spnkr.parsers.pydantic.ugc_discovery.UgcGameVariant]
-            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
-
-        Returns:
-            The game variant details.
-        """
-        endpoint = f"/hi/ugcGameVariants/{asset_id}/versions/{version_id}"
-        url = f"{UGC_DISCOVERY_HOST}{endpoint}"
-        return await self._get(url)
-
-    async def get_map_mode_pair(
-        self, asset_id: str | UUID, version_id: str | UUID
-    ) -> ClientResponse:
-        """Get details about a map mode pair.
-
-        Args:
-            asset_id: The asset ID of the map mode pair.
-            version_id: The version ID of the map mode pair.
-
-        Parsers:
-            - [MapModePair][spnkr.parsers.pydantic.ugc_discovery.MapModePair]
-            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
-
-        Returns:
-            The map mode pair details.
-        """
-        endpoint = f"/hi/mapModePairs/{asset_id}/versions/{version_id}"
-        url = f"{UGC_DISCOVERY_HOST}{endpoint}"
-        return await self._get(url)
-
-    async def get_map(
-        self, asset_id: str | UUID, version_id: str | UUID
-    ) -> ClientResponse:
-        """Get details about a map.
-
-        Args:
-            asset_id: The asset ID of the map.
-            version_id: The version ID of the map.
-
-        Parsers:
-            - [Map][spnkr.parsers.pydantic.ugc_discovery.Map]
-            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
-
-        Returns:
-            The map details.
-        """
-        endpoint = f"/hi/maps/{asset_id}/versions/{version_id}"
-        url = f"{UGC_DISCOVERY_HOST}{endpoint}"
-        return await self._get(url)
-
-    async def get_playlist(
-        self, asset_id: str | UUID, version_id: str | UUID
-    ) -> ClientResponse:
-        """Get details about a playlist.
-
-        Args:
-            asset_id: The asset ID of the playlist.
-            version_id: The version ID of the playlist.
-
-        Parsers:
-            - [Playlist][spnkr.parsers.pydantic.ugc_discovery.Playlist]
-            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
-
-        Returns:
-            The playlist details.
-        """
-        endpoint = f"/hi/playlists/{asset_id}/versions/{version_id}"
-        url = f"{UGC_DISCOVERY_HOST}{endpoint}"
-        return await self._get(url)
-
-    async def _get_user(self, user: str) -> ClientResponse:
-        return await self._get(f"{PROFILE_HOST}/users/{user}")
-
-    async def get_current_user(self) -> ClientResponse:
-        """Get the current user profile.
-
-        Parsers:
-            - [User][spnkr.parsers.pydantic.profile.User]
-            - [parse_user][spnkr.parsers.records.profile.parse_user]
-
-        Returns:
-            The user.
-        """
-        return await self._get_user("me")
-
-    async def get_user_by_gamertag(self, gamertag: str) -> ClientResponse:
-        """Get user profile for the given gamertag.
-
-        Args:
-            gamertag: The gamertag of the player.
-
-        Parsers:
-            - [User][spnkr.parsers.pydantic.profile.User]
-            - [parse_user][spnkr.parsers.records.profile.parse_user]
-
-        Returns:
-            The user.
-        """
-        return await self._get_user(f"gt({gamertag})")
-
-    async def get_user_by_id(self, xuid: str | int) -> ClientResponse:
-        """Get user profile for the given Xbox Live ID.
-
-        Args:
-            xuid: The Xbox Live ID of the player.
-
-        Parsers:
-            - [User][spnkr.parsers.pydantic.profile.User]
-            - [parse_user][spnkr.parsers.records.profile.parse_user]
-
-        Returns:
-            The user.
-        """
-        return await self._get_user(wrap_xuid(xuid))
-
-    async def get_users_by_id(
-        self, xuids: Iterable[str | int]
-    ) -> ClientResponse:
-        """Get user profiles for the given list of Xbox Live IDs.
-
-        Note that the JSON response is an array. This differs from the other
-        endpoints, which return a single JSON object.
-
-        Args:
-            xuids: The Xbox Live IDs of the players.
-
-        Parsers:
-            - [User][spnkr.parsers.pydantic.profile.User]
-            - [parse_users][spnkr.parsers.records.profile.parse_users]
-
-        Returns:
-            A list of users.
-        """
-        url = f"{PROFILE_HOST}/users"
-        params = {"xuids": [unwrap_xuid(x) for x in xuids]}
-        return await self._get(url, params=params)
+        self._requests_per_second = requests_per_second
+
+    @cached_property
+    def profile(self) -> ProfileService:
+        """Profile data service. Get user data, such as XUIDs/gamertags."""
+        return ProfileService(self._session, self._requests_per_second)
+
+    @cached_property
+    def gamecms_hacs(self) -> GameCmsHacsService:
+        """Game content management data service (e.g., medal metadata)"""
+        return GameCmsHacsService(self._session, self._requests_per_second)
+
+    @cached_property
+    def skill(self) -> SkillService:
+        """Skill data service. Retrieve MMR and CSR data by match or playlist."""
+        return SkillService(self._session, self._requests_per_second)
+
+    @cached_property
+    def stats(self) -> StatsService:
+        """Stats data service. Retrieve match history and match stats."""
+        return StatsService(self._session, self._requests_per_second)
+
+    @cached_property
+    def discovery_ugc(self) -> DiscoveryUgcService:
+        """User-generated content discovery data service (maps, modes, etc.)."""
+        return DiscoveryUgcService(self._session, self._requests_per_second)

--- a/spnkr/client.py
+++ b/spnkr/client.py
@@ -1,10 +1,4 @@
-"""Provides a client for the Halo Infinite API.
-
-Endpoints are documented at:
-https://settings.svc.halowaypoint.com/settings/hipc/e2a0a7c6-6efe-42af-9283-c2ab73250c48
-
-Additionally inspected the network traffic while navigating Halo Waypoint.
-"""
+"""Provides a client for the Halo Infinite API."""
 
 from functools import cached_property
 

--- a/spnkr/services/__init__.py
+++ b/spnkr/services/__init__.py
@@ -1,4 +1,8 @@
-"""Halo Infinite data services."""
+"""Services available for retrieving Halo Infinite data.
+
+Access service instances via
+[HaloInfiniteClient][spnkr.client.HaloInfiniteClient] properties.
+"""
 
 from .discovery_ugc import DiscoveryUgcService
 from .gamecms_hacs import GameCmsHacsService

--- a/spnkr/services/__init__.py
+++ b/spnkr/services/__init__.py
@@ -1,0 +1,15 @@
+"""Halo Infinite data services."""
+
+from .discovery_ugc import DiscoveryUgcService
+from .gamecms_hacs import GameCmsHacsService
+from .profile import ProfileService
+from .skill import SkillService
+from .stats import StatsService
+
+__all__ = [
+    "DiscoveryUgcService",
+    "GameCmsHacsService",
+    "ProfileService",
+    "SkillService",
+    "StatsService",
+]

--- a/spnkr/services/base.py
+++ b/spnkr/services/base.py
@@ -1,0 +1,36 @@
+"""Base service class."""
+
+from aiohttp import ClientResponse, ClientSession
+from aiolimiter import AsyncLimiter
+
+
+def _create_limiter(rate_per_second: int) -> AsyncLimiter:
+    """Return an AsyncLimiter with the given rate per second."""
+    # Setting the max rate to 1 disallows bursts.
+    return AsyncLimiter(1, 1 / rate_per_second)
+
+
+class BaseService:
+    """Base service class. Handles initialization and rate limiting requests."""
+
+    def __init__(
+        self, session: ClientSession, requests_per_second: int | None = 5
+    ) -> None:
+        """Initialize a service.
+
+        Args:
+            session: The authenticated aiohttp session to use.
+            requests_per_second: The rate limit to use. Set to None to disable
+                rate limiting.
+        """
+        self._session = session
+        self._rate_limiter = None
+        if requests_per_second is not None:
+            self._rate_limiter = _create_limiter(requests_per_second)
+
+    async def _get(self, url: str, **kwargs) -> ClientResponse:
+        """Make a GET request to the given URL."""
+        if self._rate_limiter is None:
+            return await self._session.get(url, **kwargs)
+        async with self._rate_limiter:
+            return await self._session.get(url, **kwargs)

--- a/spnkr/services/discovery_ugc.py
+++ b/spnkr/services/discovery_ugc.py
@@ -1,0 +1,91 @@
+"""User-generated content discovery data services."""
+
+from uuid import UUID
+
+from aiohttp import ClientResponse
+
+from .base import BaseService
+
+_HOST = "https://discovery-infiniteugc.svc.halowaypoint.com:443"
+
+
+class DiscoveryUgcService(BaseService):
+    """User-generated content discovery data services."""
+
+    async def _get_asset(
+        self, asset_type: str, asset_id: str | UUID, version_id: str | UUID
+    ) -> ClientResponse:
+        url = f"{_HOST}/hi/{asset_type}/{asset_id}/versions/{version_id}"
+        return await self._get(url)
+
+    async def get_ugc_game_variant(
+        self, asset_id: str | UUID, version_id: str | UUID
+    ) -> ClientResponse:
+        """Get details about a game mode.
+
+        Args:
+            asset_id: The asset ID of the game variant.
+            version_id: The version ID of the game variant.
+
+        Parsers:
+            - [UgcGameVariant][spnkr.parsers.pydantic.ugc_discovery.UgcGameVariant]
+            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
+
+        Returns:
+            The game variant details.
+        """
+        return await self._get_asset("ugcGameVariants", asset_id, version_id)
+
+    async def get_map_mode_pair(
+        self, asset_id: str | UUID, version_id: str | UUID
+    ) -> ClientResponse:
+        """Get details about a map mode pair.
+
+        Args:
+            asset_id: The asset ID of the map mode pair.
+            version_id: The version ID of the map mode pair.
+
+        Parsers:
+            - [MapModePair][spnkr.parsers.pydantic.ugc_discovery.MapModePair]
+            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
+
+        Returns:
+            The map mode pair details.
+        """
+        return await self._get_asset("mapModePairs", asset_id, version_id)
+
+    async def get_map(
+        self, asset_id: str | UUID, version_id: str | UUID
+    ) -> ClientResponse:
+        """Get details about a map.
+
+        Args:
+            asset_id: The asset ID of the map.
+            version_id: The version ID of the map.
+
+        Parsers:
+            - [Map][spnkr.parsers.pydantic.ugc_discovery.Map]
+            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
+
+        Returns:
+            The map details.
+        """
+        return await self._get_asset("maps", asset_id, version_id)
+
+    async def get_playlist(
+        self, asset_id: str | UUID, version_id: str | UUID
+    ) -> ClientResponse:
+        """Get details about a playlist.
+
+        Args:
+            asset_id: The asset ID of the playlist.
+            version_id: The version ID of the playlist.
+
+        Parsers:
+            - [Playlist][spnkr.parsers.pydantic.ugc_discovery.Playlist]
+            - [parse_asset][spnkr.parsers.records.ugc_discovery.parse_asset]
+
+        Returns:
+            The playlist details.
+        """
+        return await self._get_asset("playlists", asset_id, version_id)

--- a/spnkr/services/gamecms_hacs.py
+++ b/spnkr/services/gamecms_hacs.py
@@ -1,0 +1,24 @@
+"""Game content management data services."""
+
+from aiohttp import ClientResponse
+
+from .base import BaseService
+
+_HOST = "https://gamecms-hacs.svc.halowaypoint.com"
+
+
+class GameCmsHacsService(BaseService):
+    """Game content management data services."""
+
+    async def get_medal_metadata(self) -> ClientResponse:
+        """Get details for all medals obtainable in the game.
+
+        Parsers:
+            - [MedalMetadata][spnkr.parsers.pydantic.gamecms_hacs.MedalMetadata]
+            - [parse_medal_metadata][spnkr.parsers.records.gamecms_hacs.parse_medal_metadata]
+
+        Returns:
+            The medal metadata.
+        """
+        url = f"{_HOST}/hi/Waypoint/file/medals/metadata.json"
+        return await self._get(url)

--- a/spnkr/services/profile.py
+++ b/spnkr/services/profile.py
@@ -1,0 +1,81 @@
+"""Profile data services."""
+
+from typing import Iterable
+
+from aiohttp import ClientResponse
+
+from ..xuid import unwrap_xuid, wrap_xuid
+from .base import BaseService
+
+_HOST = "https://profile.svc.halowaypoint.com"
+
+
+class ProfileService(BaseService):
+    """Profile data services."""
+
+    async def _get_user(self, user: str) -> ClientResponse:
+        return await self._get(f"{_HOST}/users/{user}")
+
+    async def get_current_user(self) -> ClientResponse:
+        """Get the current user profile.
+
+        Parsers:
+            - [User][spnkr.parsers.pydantic.profile.User]
+            - [parse_user][spnkr.parsers.records.profile.parse_user]
+
+        Returns:
+            The user.
+        """
+        return await self._get_user("me")
+
+    async def get_user_by_gamertag(self, gamertag: str) -> ClientResponse:
+        """Get user profile for the given gamertag.
+
+        Args:
+            gamertag: The gamertag of the player.
+
+        Parsers:
+            - [User][spnkr.parsers.pydantic.profile.User]
+            - [parse_user][spnkr.parsers.records.profile.parse_user]
+
+        Returns:
+            The user.
+        """
+        return await self._get_user(f"gt({gamertag})")
+
+    async def get_user_by_id(self, xuid: str | int) -> ClientResponse:
+        """Get user profile for the given Xbox Live ID.
+
+        Args:
+            xuid: The Xbox Live ID of the player.
+
+        Parsers:
+            - [User][spnkr.parsers.pydantic.profile.User]
+            - [parse_user][spnkr.parsers.records.profile.parse_user]
+
+        Returns:
+            The user.
+        """
+        return await self._get_user(wrap_xuid(xuid))
+
+    async def get_users_by_id(
+        self, xuids: Iterable[str | int]
+    ) -> ClientResponse:
+        """Get user profiles for the given list of Xbox Live IDs.
+
+        Note that the JSON response is an array. This differs from the other
+        endpoints, which return a single JSON object.
+
+        Args:
+            xuids: The Xbox Live IDs of the players.
+
+        Parsers:
+            - [User][spnkr.parsers.pydantic.profile.User]
+            - [parse_users][spnkr.parsers.records.profile.parse_users]
+
+        Returns:
+            A list of users.
+        """
+        url = f"{_HOST}/users"
+        params = {"xuids": [unwrap_xuid(x) for x in xuids]}
+        return await self._get(url, params=params)

--- a/spnkr/services/skill.py
+++ b/spnkr/services/skill.py
@@ -1,0 +1,56 @@
+"""Skill data services."""
+
+from typing import Iterable
+from uuid import UUID
+
+from aiohttp import ClientResponse
+
+from ..xuid import wrap_xuid
+from .base import BaseService
+
+_HOST = "https://skill.svc.halowaypoint.com:443"
+
+
+class SkillService(BaseService):
+    """Skill data services."""
+
+    async def get_match_skill(
+        self, match_id: str | UUID, xuids: Iterable[str | int]
+    ) -> ClientResponse:
+        """Get player CSR and team MMR values for a given match and player list.
+
+        Args:
+            match_id: Halo Infinite match ID.
+            xuids: The Xbox Live IDs of the match's players. Only
+                players in this list will have their skill data returned.
+
+        Parsers:
+            - [MatchSkill][spnkr.parsers.pydantic.skill.MatchSkill]
+            - [parse_match_skill][spnkr.parsers.records.skill.parse_match_skill]
+
+        Returns:
+            The skill data for the match.
+        """
+        url = f"{_HOST}/hi/matches/{match_id}/skill"
+        params = {"players": [wrap_xuid(x) for x in xuids]}
+        return await self._get(url, params=params)
+
+    async def get_playlist_csr(
+        self, playlist_id: str | UUID, xuids: Iterable[str | int]
+    ) -> ClientResponse:
+        """Get player CSR values for a given playlist and player list.
+
+        Args:
+            playlist_id: Halo Infinite playlist asset ID.
+            xuids: The Xbox Live IDs of the players.
+
+        Parsers:
+            - [PlaylistCsr][spnkr.parsers.pydantic.skill.PlaylistCsr]
+            - [parse_playlist_csr][spnkr.parsers.records.skill.parse_playlist_csr]
+
+        Returns:
+            The summary CSR data for the players in the given playlist.
+        """
+        url = f"{_HOST}/hi/playlist/{playlist_id}/csrs"
+        params = {"players": [wrap_xuid(x) for x in xuids]}
+        return await self._get(url, params=params)

--- a/spnkr/services/stats.py
+++ b/spnkr/services/stats.py
@@ -1,0 +1,177 @@
+"""Stats data services."""
+
+import warnings
+from typing import Literal
+from uuid import UUID
+
+from aiohttp import ClientResponse
+
+from ..parsers.refdata import GameVariantCategory
+from ..xuid import wrap_xuid_or_gamertag
+from .base import BaseService
+
+_HOST = "https://halostats.svc.halowaypoint.com:443"
+_VALID_SERVICE_RECORD_FILTER_SETS = [
+    {"season_id"},
+    {"season_id", "game_variant_category"},
+    {"season_id", "game_variant_category", "playlist_asset_id"},
+    {"season_id", "game_variant_category", "is_ranked"},
+    {"season_id", "playlist_asset_id"},
+    {"game_variant_category"},
+    {"game_variant_category", "is_ranked"},
+]
+
+
+class StatsService(BaseService):
+    """Stats data services."""
+
+    async def get_match_count(self, player: str | int) -> ClientResponse:
+        """Get match counts across different game experiences for a player.
+
+        The counts returned are for custom matches, matchmade matches, local
+        matches, and total matches.
+
+        Args:
+            player: Xbox Live ID or gamertag of the player to get counts for.
+                Examples of valid inputs include "xuid(1234567890123456)",
+                "1234567890123456", 1234567890123456, and "MyGamertag".
+
+        Parsers:
+            - [MatchCount][spnkr.parsers.pydantic.stats.MatchCount]
+            - [parse_match_count][spnkr.parsers.records.stats.parse_match_count]
+
+        Returns:
+            The match counts.
+        """
+        xuid_or_gamertag = wrap_xuid_or_gamertag(player)
+        url = f"{_HOST}/hi/players/{xuid_or_gamertag}/matches/count"
+        return await self._get(url)
+
+    async def get_service_record(
+        self,
+        player: str | int,
+        match_type: Literal["matchmade", "custom", "local"] = "matchmade",
+        season_id: str | None = None,
+        game_variant_category: GameVariantCategory | int | None = None,
+        is_ranked: bool | None = None,
+        playlist_asset_id: str | UUID | None = None,
+    ) -> ClientResponse:
+        """Get a service record for a player. Summarizes player stats.
+
+        Note that filters (`season_id`, `game_variant_category`, `is_ranked`,
+        and `playlist_asset_id`) are only applicable to "matchmade"
+        `match_type`. A warning is issued and the filters are ignored if they
+        are provided for a non-matchmade `match_type`.
+
+        Filters must be combined appropriately. The following are valid:
+        - `season_id`
+        - `season_id`, `game_variant_category`
+        - `season_id`, `game_variant_category`, `playlist_asset_id`
+        - `season_id`, `game_variant_category`, `is_ranked`
+        - `season_id`, `playlist_asset_id`
+        - `game_variant_category`
+        - `game_variant_category`, `is_ranked`
+
+        To collect possible values for the filter arguments, look at the
+        "subqueries" attribute of an unfiltered service record response.
+
+        Args:
+            player: Xbox Live ID or gamertag of the player to get counts for.
+                Examples of valid inputs include "xuid(1234567890123456)",
+                "1234567890123456", 1234567890123456, and "MyGamertag".
+            match_type: The type of games to include in the service record.
+                One of "matchmade", "custom", or "local".
+            season_id: The season ID to get service record for. Optional.
+            game_variant_category: The game variant category to filter service
+                record data. See `spnkr.parsers.refdata.GameVariantCategory` for
+                human-readable values. Optional.
+            is_ranked: Filter for ranked or unranked games. Optional.
+            playlist_asset_id: Filter for a specific playlist with its asset ID.
+                Optional.
+
+        Parsers:
+            - [ServiceRecord][spnkr.parsers.pydantic.stats.ServiceRecord]
+            - [parse_service_record][spnkr.parsers.records.stats.parse_service_record]
+
+        Returns:
+            The service record for the player with the given filters.
+
+        Raises:
+            ValueError: If `match_type` is not one of "matchmade", "custom", or
+                "local".
+            ValueError: If filter arguments are inappropriately combined.
+        """
+        if match_type.lower() not in ("matchmade", "custom", "local"):
+            raise ValueError(f"Invalid match type: {match_type}")
+        xuid_or_gamertag = wrap_xuid_or_gamertag(player)
+        endpoint = f"/hi/players/{xuid_or_gamertag}/{match_type}/servicerecord"
+        url = f"{_HOST}{endpoint}"
+        filters = {
+            "season_id": season_id,
+            "game_variant_category": game_variant_category,
+            "is_ranked": is_ranked,
+            "playlist_asset_id": playlist_asset_id,
+        }
+        filters = {k: v for k, v in filters.items() if v is not None}
+        if match_type.lower() != "matchmade" and filters:
+            warnings.warn(
+                "Service record filters are only applicable to matchmade games."
+            )
+            filters = {}
+        if filters and set(filters) not in _VALID_SERVICE_RECORD_FILTER_SETS:
+            valid = "\n".join(str(s) for s in _VALID_SERVICE_RECORD_FILTER_SETS)
+            raise ValueError(
+                f"Invalid filter combination: {filters}. Options:\n{valid}"
+            )
+        params = {k.replace("_", ""): str(v) for k, v in filters.items()}
+        return await self._get(url, params=params)
+
+    async def get_match_history(
+        self,
+        player: str | int,
+        start: int = 0,
+        count: int = 25,
+        match_type: Literal["all", "matchmaking", "custom", "local"] = "all",
+    ) -> ClientResponse:
+        """Request a batch of matches from a player's match history.
+
+        Args:
+            player: Xbox Live ID or gamertag of the player to get counts for.
+                Examples of valid inputs include "xuid(1234567890123456)",
+                "1234567890123456", 1234567890123456, and "MyGamertag".
+            start: Index of the first match to request, starting at 0.
+            count: The number of matches to request. Maximum number of results
+                returned is 25.
+            match_type: The type of matches to return. One of "all",
+                "matchmaking", "custom", or "local".
+
+        Parsers:
+            - [MatchHistory][spnkr.parsers.pydantic.stats.MatchHistory]
+            - [parse_match_history][spnkr.parsers.records.stats.parse_match_history]
+
+        Returns:
+            The requested match history "page" of results.
+        """
+        xuid_or_gamertag = wrap_xuid_or_gamertag(player)
+        url = f"{_HOST}/hi/players/{xuid_or_gamertag}/matches"
+        params = {"start": start, "count": count, "type": match_type}
+        return await self._get(url, params=params)
+
+    async def get_match_stats(self, match_id: str | UUID) -> ClientResponse:
+        """Request match details using the Halo Infinite match GUID.
+
+        Args:
+            match_id: Halo Infinite GUID identifying the match.
+
+        Parsers:
+            - [MatchStats][spnkr.parsers.pydantic.stats.MatchStats]
+            - [parse_match_info][spnkr.parsers.records.stats.parse_match_info]
+            - [parse_player_core_stats][spnkr.parsers.records.stats.parse_player_core_stats]
+            - [parse_player_medals][spnkr.parsers.records.stats.parse_player_medals]
+            - [parse_team_core_stats][spnkr.parsers.records.stats.parse_team_core_stats]
+
+        Returns:
+            The match details.
+        """
+        url = f"{_HOST}/hi/matches/{match_id}/stats"
+        return await self._get(url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Configuration for pytest."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class MockSession:
+    def __init__(self) -> None:
+        self.headers = {}
+        self.get = AsyncMock()
+
+
+@pytest.fixture
+def session():
+    return MockSession()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,28 +1,26 @@
 """Test the SPNKR API client."""
 
+import asyncio
 import time
-from unittest.mock import AsyncMock
 
 import pytest
 
 from spnkr.client import HaloInfiniteClient
-
-
-class MockSession:
-    def __init__(self) -> None:
-        self.headers = {}
-        self.get = AsyncMock()
-
-
-SESSION = MockSession()
+from spnkr.services import (
+    DiscoveryUgcService,
+    GameCmsHacsService,
+    ProfileService,
+    SkillService,
+    StatsService,
+)
 
 
 @pytest.fixture
-def client():
-    return HaloInfiniteClient(SESSION, "spartan", "clearance")  # type: ignore
+def client(session):
+    return HaloInfiniteClient(session, "spartan", "clearance", 5)
 
 
-def test_header_update(client: HaloInfiniteClient):
+def test_client_header_update(client: HaloInfiniteClient):
     """Test that the client headers are updated as expected."""
     assert client._session.headers == {
         "Accept": "application/json",
@@ -31,222 +29,28 @@ def test_header_update(client: HaloInfiniteClient):
     }
 
 
-def test_async_limiter_set(client: HaloInfiniteClient):
-    """Test that the async limiter is set as expected."""
-    assert client._rate_limiter is not None
-    assert client._rate_limiter.max_rate / client._rate_limiter.time_period == 5
+def test_client_services(client: HaloInfiniteClient):
+    """Test that the client services are created as expected."""
+    assert isinstance(client.discovery_ugc, DiscoveryUgcService)
+    assert isinstance(client.gamecms_hacs, GameCmsHacsService)
+    assert isinstance(client.profile, ProfileService)
+    assert isinstance(client.skill, SkillService)
+    assert isinstance(client.stats, StatsService)
 
 
 @pytest.mark.asyncio
-async def test_rate_limiter(client: HaloInfiniteClient):
-    """Test that the rate limiter limits requests as expected."""
+async def test_client_requests_per_second_multiple_services(
+    client: HaloInfiniteClient,
+):
+    """Test that requests per second is applied per service."""
+    tasks = []
+    for _ in range(3):
+        tasks.append(client.discovery_ugc._get(""))
+        tasks.append(client.gamecms_hacs._get(""))
+        tasks.append(client.profile._get(""))
+        tasks.append(client.skill._get(""))
+        tasks.append(client.stats._get(""))
     t0 = time.time()
-    # Use 6 requests due to the default rate of 5 requests per second.
-    for _ in range(6):
-        await client._get("url")
+    await asyncio.gather(*tasks)
     t1 = time.time()
-    assert t1 - t0 >= 1
-
-
-@pytest.mark.asyncio
-async def test_rate_limiter_none(client: HaloInfiniteClient):
-    """Test that the rate limiter does not limit requests if None."""
-    client._rate_limiter = None
-    t0 = time.time()
-    for _ in range(6):
-        await client._get("url")
-    t1 = time.time()
-    assert t1 - t0 < 1
-
-
-@pytest.mark.asyncio
-async def test_get_medal_metadata(client: HaloInfiniteClient):
-    await client.get_medal_metadata()
-    SESSION.get.assert_called_with(
-        "https://gamecms-hacs.svc.halowaypoint.com/hi/Waypoint/file/medals/metadata.json"
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_map_mode_pair(client: HaloInfiniteClient):
-    await client.get_map_mode_pair("asset_id", "version_id")
-    SESSION.get.assert_called_with(
-        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/mapModePairs/asset_id/versions/version_id"
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_playlist(client: HaloInfiniteClient):
-    await client.get_playlist("asset_id", "version_id")
-    SESSION.get.assert_called_with(
-        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/playlists/asset_id/versions/version_id"
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_map(client: HaloInfiniteClient):
-    await client.get_map("asset_id", "version_id")
-    SESSION.get.assert_called_with(
-        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/maps/asset_id/versions/version_id"
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_ugc_game_variant(client: HaloInfiniteClient):
-    await client.get_ugc_game_variant("asset_id", "version_id")
-    SESSION.get.assert_called_with(
-        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/ugcGameVariants/asset_id/versions/version_id"
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_match_skill(client: HaloInfiniteClient):
-    await client.get_match_skill("match_id", [1234567890123456])
-    SESSION.get.assert_called_with(
-        "https://skill.svc.halowaypoint.com:443/hi/matches/match_id/skill",
-        params={"players": ["xuid(1234567890123456)"]},
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_playlist_csr(client: HaloInfiniteClient):
-    await client.get_playlist_csr(
-        "playlist_id", [1234567890123456, 2345678901234567]
-    )
-    SESSION.get.assert_called_with(
-        "https://skill.svc.halowaypoint.com:443/hi/playlist/playlist_id/csrs",
-        params={
-            "players": ["xuid(1234567890123456)", "xuid(2345678901234567)"]
-        },
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_match_count(client: HaloInfiniteClient):
-    await client.get_match_count(1234567890123456)
-    SESSION.get.assert_called_with(
-        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matches/count"
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_service_record(client: HaloInfiniteClient):
-    await client.get_service_record(1234567890123456)
-    SESSION.get.assert_called_with(
-        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matchmade/servicerecord",
-        params={},
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_service_record_season_playlist(client: HaloInfiniteClient):
-    await client.get_service_record(
-        1234567890123456,
-        season_id="season_id",
-        playlist_asset_id="playlist_asset_id",
-    )
-    SESSION.get.assert_called_with(
-        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matchmade/servicerecord",
-        params={
-            "seasonid": "season_id",
-            "playlistassetid": "playlist_asset_id",
-        },
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_service_record_game_variant_category_ranked(
-    client: HaloInfiniteClient,
-):
-    await client.get_service_record(
-        1234567890123456, game_variant_category=6, is_ranked=True
-    )
-    SESSION.get.assert_called_with(
-        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matchmade/servicerecord",
-        params={"gamevariantcategory": "6", "isranked": "True"},
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_service_record_invalid_match_type(
-    client: HaloInfiniteClient,
-):
-    with pytest.raises(ValueError):
-        await client.get_service_record(1234567890123456, match_type="invalid")  # type: ignore
-
-
-@pytest.mark.asyncio
-async def test_get_service_record_invalid_filter_combination(
-    client: HaloInfiniteClient,
-):
-    with pytest.raises(ValueError):
-        await client.get_service_record(1234567890123456, playlist_asset_id="")
-
-
-@pytest.mark.asyncio
-async def test_get_service_record_non_matchmade_params_ignored(
-    client: HaloInfiniteClient,
-):
-    await client.get_service_record(
-        1234567890123456, match_type="custom", is_ranked=True
-    )
-    SESSION.get.assert_called_with(
-        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/custom/servicerecord",
-        params={},
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_match_history(client: HaloInfiniteClient):
-    await client.get_match_history(1234567890123456, 0, 10, "all")
-    SESSION.get.assert_called_with(
-        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matches",
-        params={"start": 0, "count": 10, "type": "all"},
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_match_stats(client: HaloInfiniteClient):
-    await client.get_match_stats("match_id")
-    SESSION.get.assert_called_with(
-        "https://halostats.svc.halowaypoint.com:443/hi/matches/match_id/stats"
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_current_user(client: HaloInfiniteClient):
-    await client.get_current_user()
-    SESSION.get.assert_called_with(
-        "https://profile.svc.halowaypoint.com/users/me",
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_user_by_gamertag(client: HaloInfiniteClient):
-    await client.get_user_by_gamertag("MyGamertag")
-    SESSION.get.assert_called_with(
-        "https://profile.svc.halowaypoint.com/users/gt(MyGamertag)",
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_user_by_id(client: HaloInfiniteClient):
-    await client.get_user_by_id("xuid(2345678901234567)")
-    SESSION.get.assert_called_with(
-        "https://profile.svc.halowaypoint.com/users/xuid(2345678901234567)",
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_users_by_id(client: HaloInfiniteClient):
-    await client.get_users_by_id(
-        ["xuid(1234567890123456)", "xuid(2345678901234567)"]
-    )
-    SESSION.get.assert_called_with(
-        "https://profile.svc.halowaypoint.com/users",
-        params={"xuids": [1234567890123456, 2345678901234567]},
-    )
-
-
-if __name__ == "__main__":
-    pytest.main()
+    assert t1 - t0 <= 1

--- a/tests/test_services_base.py
+++ b/tests/test_services_base.py
@@ -1,0 +1,42 @@
+"""Test BaseService."""
+
+import time
+
+import pytest
+
+from spnkr.services.base import BaseService
+
+
+@pytest.fixture
+def service(session):
+    return BaseService(session)
+
+
+def test_async_limiter_set(service: BaseService):
+    """Test that the async limiter is set as expected."""
+    assert service._rate_limiter is not None
+    assert (
+        service._rate_limiter.max_rate / service._rate_limiter.time_period == 5
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter(service: BaseService):
+    """Test that the rate limiter limits requests as expected."""
+    t0 = time.time()
+    # Use 6 requests due to the default rate of 5 requests per second.
+    for _ in range(6):
+        await service._get("url")
+    t1 = time.time()
+    assert t1 - t0 >= 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_none(service: BaseService):
+    """Test that the rate limiter does not limit requests if None."""
+    service._rate_limiter = None
+    t0 = time.time()
+    for _ in range(6):
+        await service._get("url")
+    t1 = time.time()
+    assert t1 - t0 < 1

--- a/tests/test_services_discovery_ugc.py
+++ b/tests/test_services_discovery_ugc.py
@@ -1,0 +1,42 @@
+"""Test DiscoveryUgcService."""
+
+import pytest
+
+from spnkr.services.discovery_ugc import DiscoveryUgcService
+
+
+@pytest.fixture
+def service(session):
+    return DiscoveryUgcService(session)
+
+
+@pytest.mark.asyncio
+async def test_get_map_mode_pair(session, service: DiscoveryUgcService):
+    await service.get_map_mode_pair("asset_id", "version_id")
+    session.get.assert_called_with(
+        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/mapModePairs/asset_id/versions/version_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_playlist(session, service: DiscoveryUgcService):
+    await service.get_playlist("asset_id", "version_id")
+    session.get.assert_called_with(
+        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/playlists/asset_id/versions/version_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_map(session, service: DiscoveryUgcService):
+    await service.get_map("asset_id", "version_id")
+    session.get.assert_called_with(
+        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/maps/asset_id/versions/version_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_ugc_game_variant(session, service: DiscoveryUgcService):
+    await service.get_ugc_game_variant("asset_id", "version_id")
+    session.get.assert_called_with(
+        "https://discovery-infiniteugc.svc.halowaypoint.com:443/hi/ugcGameVariants/asset_id/versions/version_id"
+    )

--- a/tests/test_services_gamecms_hacs.py
+++ b/tests/test_services_gamecms_hacs.py
@@ -1,0 +1,18 @@
+"""Test GameContentHacsService."""
+
+import pytest
+
+from spnkr.services.gamecms_hacs import GameCmsHacsService
+
+
+@pytest.fixture
+def service(session):
+    return GameCmsHacsService(session)
+
+
+@pytest.mark.asyncio
+async def test_get_medal_metadata(session, service: GameCmsHacsService):
+    await service.get_medal_metadata()
+    session.get.assert_called_with(
+        "https://gamecms-hacs.svc.halowaypoint.com/hi/Waypoint/file/medals/metadata.json"
+    )

--- a/tests/test_services_profile.py
+++ b/tests/test_services_profile.py
@@ -1,0 +1,45 @@
+"""Test ProfileService."""
+
+import pytest
+
+from spnkr.services.profile import ProfileService
+
+
+@pytest.fixture
+def service(session):
+    return ProfileService(session)
+
+
+@pytest.mark.asyncio
+async def test_get_current_user(session, service: ProfileService):
+    await service.get_current_user()
+    session.get.assert_called_with(
+        "https://profile.svc.halowaypoint.com/users/me",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_gamertag(session, service: ProfileService):
+    await service.get_user_by_gamertag("MyGamertag")
+    session.get.assert_called_with(
+        "https://profile.svc.halowaypoint.com/users/gt(MyGamertag)",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_id(session, service: ProfileService):
+    await service.get_user_by_id("xuid(2345678901234567)")
+    session.get.assert_called_with(
+        "https://profile.svc.halowaypoint.com/users/xuid(2345678901234567)",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_id(session, service: ProfileService):
+    await service.get_users_by_id(
+        ["xuid(1234567890123456)", "xuid(2345678901234567)"]
+    )
+    session.get.assert_called_with(
+        "https://profile.svc.halowaypoint.com/users",
+        params={"xuids": [1234567890123456, 2345678901234567]},
+    )

--- a/tests/test_services_skill.py
+++ b/tests/test_services_skill.py
@@ -1,0 +1,32 @@
+"""Test SkillService."""
+
+import pytest
+
+from spnkr.services.skill import SkillService
+
+
+@pytest.fixture
+def service(session):
+    return SkillService(session)
+
+
+@pytest.mark.asyncio
+async def test_get_match_skill(session, service: SkillService):
+    await service.get_match_skill("match_id", [1234567890123456])
+    session.get.assert_called_with(
+        "https://skill.svc.halowaypoint.com:443/hi/matches/match_id/skill",
+        params={"players": ["xuid(1234567890123456)"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_playlist_csr(session, service: SkillService):
+    await service.get_playlist_csr(
+        "playlist_id", [1234567890123456, 2345678901234567]
+    )
+    session.get.assert_called_with(
+        "https://skill.svc.halowaypoint.com:443/hi/playlist/playlist_id/csrs",
+        params={
+            "players": ["xuid(1234567890123456)", "xuid(2345678901234567)"]
+        },
+    )

--- a/tests/test_services_stats.py
+++ b/tests/test_services_stats.py
@@ -1,0 +1,103 @@
+"""Test StatsService."""
+
+import pytest
+
+from spnkr.services.stats import StatsService
+
+
+@pytest.fixture
+def service(session):
+    return StatsService(session)
+
+
+@pytest.mark.asyncio
+async def test_get_match_count(session, service: StatsService):
+    await service.get_match_count(1234567890123456)
+    session.get.assert_called_with(
+        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matches/count"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_service_record(session, service: StatsService):
+    await service.get_service_record(1234567890123456)
+    session.get.assert_called_with(
+        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matchmade/servicerecord",
+        params={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_service_record_season_playlist(
+    session, service: StatsService
+):
+    await service.get_service_record(
+        1234567890123456,
+        season_id="season_id",
+        playlist_asset_id="playlist_asset_id",
+    )
+    session.get.assert_called_with(
+        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matchmade/servicerecord",
+        params={
+            "seasonid": "season_id",
+            "playlistassetid": "playlist_asset_id",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_service_record_game_variant_category_ranked(
+    session, service: StatsService
+):
+    await service.get_service_record(
+        1234567890123456, game_variant_category=6, is_ranked=True
+    )
+    session.get.assert_called_with(
+        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matchmade/servicerecord",
+        params={"gamevariantcategory": "6", "isranked": "True"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_service_record_invalid_match_type(service: StatsService):
+    with pytest.raises(ValueError):
+        await service.get_service_record(1234567890123456, match_type="invalid")  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_get_service_record_invalid_filter_combination(
+    service: StatsService,
+):
+    with pytest.raises(ValueError):
+        await service.get_service_record(1234567890123456, playlist_asset_id="")
+
+
+@pytest.mark.asyncio
+async def test_get_service_record_non_matchmade_params_ignored(
+    session,
+    service: StatsService,
+):
+    await service.get_service_record(
+        1234567890123456, match_type="custom", is_ranked=True
+    )
+    session.get.assert_called_with(
+        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/custom/servicerecord",
+        params={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_match_history(session, service: StatsService):
+    await service.get_match_history(1234567890123456, 0, 10, "all")
+    session.get.assert_called_with(
+        "https://halostats.svc.halowaypoint.com:443/hi/players/xuid(1234567890123456)/matches",
+        params={"start": 0, "count": 10, "type": "all"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_match_stats(session, service: StatsService):
+    await service.get_match_stats("match_id")
+    session.get.assert_called_with(
+        "https://halostats.svc.halowaypoint.com:443/hi/matches/match_id/stats"
+    )


### PR DESCRIPTION
Grouped endpoints by their URL hosts to create a `services` module. The data retrieval methods didn't change, but they did move to their respective service classes. `HaloInfiniteClient` remains the core API entrypoint, but now indirectly serves data via cached service properties `gamecms_hacs`, `profile`, `discovery_ugc`, `skill`, and `stats`. This will make adding more services and endpoints more graceful than just appending more methods to the client class. Additionally, this design makes it easy to rate-limit requests per host rather than globally.

Closes #11 