### PR TITLE
Add `HaloInfiniteClient` wrapper for match-related API requests.

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -117,4 +117,44 @@ Calls to [HaloInfiniteClient](reference/client.md) services return parsed JSON p
 
 Of course, there are additional methods for retrieving stats, CSR/MMR, and metadata information.
 
-[Next: Services](reference/services.md){ .md-button }
+[Services](reference/services.md){ .md-button }
+
+## Match API
+
+An alternative API for requesting match-related data is available via a client-wrapping [Match](reference/match.md) class. A `Match` instance maintains a reference to the client and a match ID to abstract from some of the details of integrating API calls. A basic example involving a metadata request is shown below.
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from spnkr.client import HaloInfiniteClient
+from spnkr.match import Match
+
+
+async def main() -> None:
+    async with ClientSession() as session:
+        client = HaloInfiniteClient(...)
+        history = await client.stats.get_match_history(...)
+        most_recent = history.results[0]
+
+        # Using the `HaloInfiniteClient` directly.
+        map_mode_pair = most_recent.playlist_map_mode_pair
+        map_mode_pair_model = await client.discovery_ugc.get_map_mode_pair(
+            map_mode_pair.asset_id, map_mode_pair.version_id
+        )
+        print(f"Last match: {map_mode_pair_model.public_name}")
+
+        # Using the `Match` wrapper. Match info argument is optional.
+        match_ = Match(client, most_recent.match_id, most_recent.match_info)
+        map_mode_pair = await match_.get_map_mode_pair()
+        print(f"Last match: {map_mode_pair.public_name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Follow the link below to see all methods available.
+
+[Match](reference/match.md){ .md-button }

--- a/docs/reference/match.md
+++ b/docs/reference/match.md
@@ -1,0 +1,5 @@
+# Match
+
+::: spnkr.match
+    options:
+        show_root_heading: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - reference/authentication.md
     - reference/client.md
     - reference/services.md
+    - reference/match.md
     - reference/models.md
     - reference/reference-data.md
     - reference/tools.md

--- a/spnkr/match.py
+++ b/spnkr/match.py
@@ -26,12 +26,9 @@ class Match:
             client: The Halo Infinite client to use for requests.
             match: The ID of the match.
             match_info: The match info. If not provided, it will be retrieved
-                with a match stats request. Providing this argument can save
-                an API request if the desired information is limited to
+                with a match stats request when needed. Providing this argument
+                saves a stats request if the desired information is limited to
                 map/mode/playlist. Available from a match history request.
-
-        Returns:
-            A match reference.
         """
         self._client = client
         self._id = match_id if isinstance(match_id, UUID) else UUID(match_id)
@@ -40,37 +37,37 @@ class Match:
 
     @property
     def id(self) -> UUID:
+        """The ID of the match."""
         return self._id
 
     async def get_stats(self) -> MatchStats:
         """Get the stats for this match."""
         if self._stats is None:
             self._stats = await self._client.stats.get_match_stats(self._id)
-            self._info = self._stats.match_info
         return self._stats
 
     async def get_info(self) -> MatchInfo:
-        """Get the info for this match."""
+        """Get the match info for this match."""
         if self._info is None:
             self._info = (await self.get_stats()).match_info
         return self._info
 
     async def get_map(self) -> Map:
-        """Get the map for this match."""
+        """Get the map this match was played on."""
         info = await self.get_info()
         return await self._client.discovery_ugc.get_map(
             info.map_variant.asset_id, info.map_variant.version_id
         )
 
     async def get_mode(self) -> UgcGameVariant:
-        """Get the game variant for this match."""
+        """Get the game mode this match was played on."""
         info = await self.get_info()
         return await self._client.discovery_ugc.get_ugc_game_variant(
             info.ugc_game_variant.asset_id, info.ugc_game_variant.version_id
         )
 
     async def get_playlist(self) -> Playlist | None:
-        """Get the playlist for this match."""
+        """Get the playlist this match was found in. Matchmaking only."""
         info = await self.get_info()
         if info.playlist is None:
             return None
@@ -79,7 +76,7 @@ class Match:
         )
 
     async def get_map_mode_pair(self) -> MapModePair | None:
-        """Get the map-mode pair for this match."""
+        """Get the map-mode pair selected for this match. Matchmaking only."""
         info = await self.get_info()
         map_mode_pair = info.playlist_map_mode_pair
         if map_mode_pair is None:
@@ -96,7 +93,7 @@ class Match:
         return {wrap_xuid(user.xuid): user for user in users}
 
     async def get_skill(self) -> MatchSkill | None:
-        """Get CSR/MMR information for this match."""
+        """Get CSR/MMR information for this match. Matchmaking only."""
         info = await self.get_info()
         if info.lifecycle_mode is not LifecycleMode.MATCHMADE:
             # Skill data is only available for matchmade games.

--- a/spnkr/match.py
+++ b/spnkr/match.py
@@ -1,0 +1,138 @@
+"""Provides a simplified API for retrieving match data."""
+
+from uuid import UUID
+
+from aiocache import cached
+
+from .client import HaloInfiniteClient
+from .models.discovery_ugc import Map, MapModePair, Playlist, UgcGameVariant
+from .models.profile import User
+from .models.refdata import LifecycleMode
+from .models.skill import MatchSkill
+from .models.stats import MatchInfo, MatchStats
+from .xuid import wrap_xuid
+
+
+class Match:
+    """A Halo Infinite match reference for simplified retrieval of match data."""
+
+    def __init__(
+        self,
+        client: HaloInfiniteClient,
+        match_id: str | UUID,
+        match_info: MatchInfo | None = None,
+    ) -> None:
+        """Create a match reference for simplified retrieval of match data.
+
+        Args:
+            client: The Halo Infinite client to use for requests.
+            match: The ID of the match.
+            match_info: The match info. If not provided, it will be retrieved
+                with a match stats request. Providing this argument can save
+                an API request if the desired information is limited to
+                map/mode/playlist. Available from a match history request.
+
+        Returns:
+            A match reference.
+        """
+        self._client = client
+        self._id = match_id if isinstance(match_id, UUID) else UUID(match_id)
+        self._info = match_info
+
+    @property
+    def id(self) -> UUID:
+        return self._id
+
+    async def get_stats(self) -> MatchStats:
+        """Get the stats for this match."""
+        return await self._get_stats()
+
+    async def get_info(self) -> MatchInfo:
+        """Get the info for this match."""
+        return await self._get_info()
+
+    async def get_map(self) -> Map:
+        """Get the map for this match."""
+        return await self._get_map()
+
+    async def get_mode(self) -> UgcGameVariant:
+        """Get the game variant for this match."""
+        return await self._get_mode()
+
+    async def get_playlist(self) -> Playlist | None:
+        """Get the playlist for this match."""
+        return await self._get_playlist()
+
+    async def get_map_mode_pair(self) -> MapModePair | None:
+        """Get the map-mode pair for this match."""
+        return await self._get_map_mode_pair()
+
+    async def get_users(self) -> dict[str, User]:
+        """Get a mapping of XUIDs to profiles for players in this match."""
+        users = await self._get_users()
+        return {wrap_xuid(user.xuid): user for user in users}
+
+    async def get_skill(self) -> MatchSkill | None:
+        """Get CSR/MMR information for this match."""
+        return await self._get_skill()
+
+    @cached()
+    async def _get_stats(self) -> MatchStats:
+        stats = await self._client.stats.get_match_stats(self._id)
+        self._info = stats.match_info
+        return stats
+
+    @cached()
+    async def _get_info(self) -> MatchInfo:
+        if self._info is None:
+            self._info = (await self.get_stats()).match_info
+        return self._info
+
+    @cached()
+    async def _get_map(self) -> Map:
+        info = await self.get_info()
+        return await self._client.discovery_ugc.get_map(
+            info.map_variant.asset_id, info.map_variant.version_id
+        )
+
+    @cached()
+    async def _get_mode(self) -> UgcGameVariant:
+        info = await self.get_info()
+        return await self._client.discovery_ugc.get_ugc_game_variant(
+            info.ugc_game_variant.asset_id, info.ugc_game_variant.version_id
+        )
+
+    @cached()
+    async def _get_playlist(self) -> Playlist | None:
+        info = await self.get_info()
+        if info.playlist is None:
+            return None
+        return await self._client.discovery_ugc.get_playlist(
+            info.playlist.asset_id, info.playlist.version_id
+        )
+
+    @cached()
+    async def _get_map_mode_pair(self) -> MapModePair | None:
+        info = await self.get_info()
+        map_mode_pair = info.playlist_map_mode_pair
+        if map_mode_pair is None:
+            return None
+        return await self._client.discovery_ugc.get_map_mode_pair(
+            map_mode_pair.asset_id, map_mode_pair.version_id
+        )
+
+    @cached()
+    async def _get_users(self) -> tuple[User, ...]:
+        stats = await self.get_stats()
+        xuids = [p.player_id for p in stats.players if p.is_human]
+        return tuple(await self._client.profile.get_users_by_id(xuids))
+
+    @cached()
+    async def _get_skill(self) -> MatchSkill | None:
+        info = await self.get_info()
+        if info.lifecycle_mode is not LifecycleMode.MATCHMADE:
+            # Skill data is only available for matchmade games.
+            return None
+        stats = await self.get_stats()
+        xuids = [p.player_id for p in stats.players if p.is_human]
+        return await self._client.skill.get_match_skill(self._id, xuids)

--- a/spnkr/match.py
+++ b/spnkr/match.py
@@ -24,7 +24,7 @@ class Match:
 
         Args:
             client: The Halo Infinite client to use for requests.
-            match: The ID of the match.
+            match_id: The ID of the match.
             match_info: The match info. If not provided, it will be retrieved
                 with a match stats request when needed. Providing this argument
                 saves a stats request if the desired information is limited to
@@ -41,33 +41,53 @@ class Match:
         return self._id
 
     async def get_stats(self) -> MatchStats:
-        """Get the stats for this match."""
+        """Get the stats for this match.
+
+        Returns:
+            The match stats.
+        """
         if self._stats is None:
             self._stats = await self._client.stats.get_match_stats(self._id)
         return self._stats
 
     async def get_info(self) -> MatchInfo:
-        """Get the match info for this match."""
+        """Get the match info for this match.
+
+        Returns:
+            The match info.
+        """
         if self._info is None:
             self._info = (await self.get_stats()).match_info
         return self._info
 
     async def get_map(self) -> Map:
-        """Get the map this match was played on."""
+        """Get the map this match was played on.
+
+        Returns:
+            The map.
+        """
         info = await self.get_info()
         return await self._client.discovery_ugc.get_map(
             info.map_variant.asset_id, info.map_variant.version_id
         )
 
     async def get_mode(self) -> UgcGameVariant:
-        """Get the game mode this match was played on."""
+        """Get the game mode this match was played on.
+
+        Returns:
+            The game mode.
+        """
         info = await self.get_info()
         return await self._client.discovery_ugc.get_ugc_game_variant(
             info.ugc_game_variant.asset_id, info.ugc_game_variant.version_id
         )
 
     async def get_playlist(self) -> Playlist | None:
-        """Get the playlist this match was found in. Matchmaking only."""
+        """Get the playlist this match was found in. Matchmaking only.
+
+        Returns:
+            The playlist if available, otherwise None.
+        """
         info = await self.get_info()
         if info.playlist is None:
             return None
@@ -76,7 +96,11 @@ class Match:
         )
 
     async def get_map_mode_pair(self) -> MapModePair | None:
-        """Get the map-mode pair selected for this match. Matchmaking only."""
+        """Get the map-mode pair selected for this match. Matchmaking only.
+
+        Returns:
+            The map-mode pair if available, otherwise None.
+        """
         info = await self.get_info()
         map_mode_pair = info.playlist_map_mode_pair
         if map_mode_pair is None:
@@ -86,14 +110,22 @@ class Match:
         )
 
     async def get_users(self) -> dict[str, User]:
-        """Get a mapping of XUIDs to profiles for players in this match."""
+        """Get a mapping of XUIDs to profiles for players in this match.
+
+        Returns:
+            A mapping of XUIDs to profiles.
+        """
         stats = await self.get_stats()
         xuids = [p.player_id for p in stats.players if p.is_human]
         users = await self._client.profile.get_users_by_id(xuids)
         return {wrap_xuid(user.xuid): user for user in users}
 
     async def get_skill(self) -> MatchSkill | None:
-        """Get CSR/MMR information for this match. Matchmaking only."""
+        """Get CSR/MMR information for this match. Matchmaking only.
+
+        Returns:
+            The skill data if available, otherwise None.
+        """
         info = await self.get_info()
         if info.lifecycle_mode is not LifecycleMode.MATCHMADE:
             # Skill data is only available for matchmade games.

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,0 +1,217 @@
+"""Test the spnkr.match module."""
+
+import json
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from spnkr.client import HaloInfiniteClient
+from spnkr.match import Match
+from spnkr.models.profile import User
+from spnkr.models.refdata import LifecycleMode
+from spnkr.models.stats import MatchInfo, MatchStats
+
+
+def get_match_stats():
+    with open("tests/responses/get_match_stats.json", "rb") as f:
+        return MatchStats(**json.load(f))
+
+
+def get_match_info():
+    return get_match_stats().match_info
+
+
+def get_users():
+    with open("tests/responses/get_users.json", "rb") as f:
+        return [User(**user) for user in json.load(f)]
+
+
+class MockStatsService:
+    def __init__(self) -> None:
+        self.get_match_stats = AsyncMock()
+        self.get_match_stats.return_value = get_match_stats()
+
+
+class MockSkillService:
+    def __init__(self) -> None:
+        self.get_match_skill = AsyncMock()
+
+
+class MockDiscoveryUgcService:
+    def __init__(self) -> None:
+        self.get_map_mode_pair = AsyncMock()
+        self.get_playlist = AsyncMock()
+        self.get_map = AsyncMock()
+        self.get_ugc_game_variant = AsyncMock()
+
+
+class MockProfileService:
+    def __init__(self) -> None:
+        self.get_users_by_id = AsyncMock()
+
+
+class MockClient:
+    def __init__(self) -> None:
+        self.stats = MockStatsService()
+        self.skill = MockSkillService()
+        self.discovery_ugc = MockDiscoveryUgcService()
+        self.profile = MockProfileService()
+
+
+@pytest.fixture
+def client():
+    return MockClient()
+
+
+@pytest.fixture
+def match(client):
+    return Match(client, "00000000-0000-0000-0000-000000000000")
+
+
+def test_match_init_str(match: Match):
+    assert match.id == UUID("00000000-0000-0000-0000-000000000000")
+
+
+def test_match_init_uuid(client):
+    match = Match(client, uuid4())
+    assert isinstance(match.id, UUID)
+
+
+@pytest.mark.asyncio
+async def test_match_caching(client, match: Match):
+    await match.get_stats()
+    await match.get_stats()
+    assert client.stats.get_match_stats.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_match_get_stats(match: Match):
+    assert match._info is None
+    stats = await match.get_stats()
+    assert str(stats.match_id) == "6f050134-bede-47bc-a6df-eeafdcb9f97f"
+    assert isinstance(match._info, MatchInfo)
+
+
+@pytest.mark.asyncio
+async def test_match_get_info_already_set(match: Match):
+    info_a = await match.get_info()
+    info_b = await match.get_info()
+    assert id(info_a) == id(info_b)
+
+
+@pytest.mark.asyncio
+async def test_match_get_info(match: Match):
+    info = await match.get_info()
+    assert info.start_time.date().isoformat() == "2022-07-27"
+
+
+@pytest.mark.asyncio
+async def test_match_get_map(client, match: Match):
+    await match.get_map()
+    client.discovery_ugc.get_map.assert_called_once_with(
+        UUID("e859cf75-9b8a-429a-91be-2376681c8537"),
+        UUID("cd1f9a4e-b02f-4eb8-89e7-b61fa1010452"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_get_map_info_set(client, match: Match):
+    match._info = get_match_info()
+    await match.get_map()
+    client.stats.get_match_stats.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_match_get_mode(client, match: Match):
+    await match.get_mode()
+    client.discovery_ugc.get_ugc_game_variant.assert_called_once_with(
+        UUID("507191c6-a492-4331-b2ae-a172101eb23e"),
+        UUID("ee8c890b-a95f-4154-bac6-0009992d74f6"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_get_playlist(client, match: Match):
+    await match.get_playlist()
+    client.discovery_ugc.get_playlist.assert_called_once_with(
+        UUID("edfef3ac-9cbe-4fa2-b949-8f29deafd483"),
+        UUID("6c1bb887-628f-4a16-a794-f07adad39a38"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_get_playlist_non_matchmade(session):
+    client = HaloInfiniteClient(session, "", "")
+    match = Match(client, uuid4())
+    match._info = get_match_info().model_copy(update={"playlist": None})
+    playlist = await match.get_playlist()
+    assert playlist is None
+
+
+@pytest.mark.asyncio
+async def test_match_get_map_mode_pair(client, match: Match):
+    await match.get_map_mode_pair()
+    client.discovery_ugc.get_map_mode_pair.assert_called_once_with(
+        UUID("69d25f16-bc62-4d58-baf7-6210f65461f3"),
+        UUID("91ca22c3-e2a8-4586-8011-a4888f175d3e"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_get_map_mode_pair_non_matchmade(session):
+    client = HaloInfiniteClient(session, "", "")
+    match = Match(client, uuid4())
+    new_data = {"playlist_map_mode_pair": None}
+    match._info = get_match_info().model_copy(update=new_data)
+    map_mode_pair = await match.get_map_mode_pair()
+    assert map_mode_pair is None
+
+
+@pytest.mark.asyncio
+async def test_match_get_users(client, match: Match):
+    await match.get_users()
+    expected_ids = [
+        "xuid(2533274797283717)",
+        "xuid(2533274892674451)",
+        "xuid(2533274974206999)",
+        "xuid(2535469531821339)",
+        "xuid(2535412760927018)",
+        "xuid(2533274876924991)",
+        "xuid(2535413591152112)",
+    ]
+    client.profile.get_users_by_id.assert_called_once_with(expected_ids)
+
+
+@pytest.mark.asyncio
+async def test_match_get_users_dict(client, match: Match):
+    client.profile.get_users_by_id.return_value = get_users()
+    users = await match.get_users()
+    assert users["xuid(1234567890123456)"].gamertag == "GAMERTAG"
+
+
+@pytest.mark.asyncio
+async def test_match_get_skill(client, match: Match):
+    await match.get_skill()
+    expected_ids = [
+        "xuid(2533274797283717)",
+        "xuid(2533274892674451)",
+        "xuid(2533274974206999)",
+        "xuid(2535469531821339)",
+        "xuid(2535412760927018)",
+        "xuid(2533274876924991)",
+        "xuid(2535413591152112)",
+    ]
+    client.skill.get_match_skill.assert_called_once_with(
+        UUID("00000000-0000-0000-0000-000000000000"), expected_ids
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_get_skill_non_matchmade(session):
+    client = HaloInfiniteClient(session, "", "")
+    match = Match(client, uuid4())
+    info = get_match_info()
+    new_data = {"lifecycle_mode": LifecycleMode.CUSTOM}
+    match._info = info.model_copy(update=new_data)
+    assert await match.get_skill() is None

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -88,11 +88,9 @@ async def test_match_get_stats_caching(client, match: Match):
 @pytest.mark.asyncio
 async def test_match_get_stats(match: Match):
     assert match._stats is None
-    assert match._info is None
     stats = await match.get_stats()
     assert str(stats.match_id) == "6f050134-bede-47bc-a6df-eeafdcb9f97f"
     assert isinstance(match._stats, MatchStats)
-    assert isinstance(match._info, MatchInfo)
 
 
 @pytest.mark.asyncio

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -79,7 +79,7 @@ def test_match_init_uuid(client):
 
 
 @pytest.mark.asyncio
-async def test_match_caching(client, match: Match):
+async def test_match_get_stats_caching(client, match: Match):
     await match.get_stats()
     await match.get_stats()
     assert client.stats.get_match_stats.call_count == 1
@@ -87,10 +87,19 @@ async def test_match_caching(client, match: Match):
 
 @pytest.mark.asyncio
 async def test_match_get_stats(match: Match):
+    assert match._stats is None
     assert match._info is None
     stats = await match.get_stats()
     assert str(stats.match_id) == "6f050134-bede-47bc-a6df-eeafdcb9f97f"
+    assert isinstance(match._stats, MatchStats)
     assert isinstance(match._info, MatchInfo)
+
+
+@pytest.mark.asyncio
+async def test_match_get_stats_already_set(match: Match):
+    stats_a = await match.get_stats()
+    stats_b = await match.get_stats()
+    assert id(stats_a) == id(stats_b)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@aapokaapo Let me know what you think of this for #15 

```python
from aiohttp import ClientSession

from spnkr.client import HaloInfiniteClient
from spnkr.match import Match


async with ClientSession() as session:
    client = HaloInfiniteClient(...)
    match = Match(client, "ca19c433-a5c1-4212-8c91-18f2b7ff85ec")
    assert str(match.id) == "ca19c433-a5c1-4212-8c91-18f2b7ff85ec"

    stats = await match.get_stats()
    assert len(stats.players) == 8

    info = await match.get_info()
    assert round(info.duration.seconds) == (9 * 60 + 27)

    map_ = await match.get_map()
    assert map_.public_name == "Argyle"

    mode = await match.get_mode()
    assert mode.public_name == "Ranked:CTF 3 Captures"

    playlist = await match.get_playlist()
    assert playlist is not None
    assert playlist.public_name == "Ranked Arena"

    map_mode_pair = await match.get_map_mode_pair()
    assert map_mode_pair is not None
    assert map_mode_pair.public_name == "Ranked:CTF 3 Captures on Argyle"

    skill = await match.get_skill()
    assert skill is not None
    assert skill.value[0].result.team_mmrs == {
        0: 962.623065450361,
        1: 975.6512043496726,
    }

    users = await match.get_users()
    assert "xuid(2535445291321133)" in users
```